### PR TITLE
Adds support for multiple strings in TXT records

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A DNS zone file parser and generator",
   "main": "lib/index",
   "scripts": {
-    "compile": "rm -rf lib; babel --presets es2015 src -d lib",
+    "compile": "rm -rf lib; babel --presets env src -d lib",
     "prepublish": "npm run compile",
     "test": "npm run compile; node lib/testing/unitTests.js"
   },
@@ -66,7 +66,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.7.5",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-env": "^1.6.1",
     "tape": "^4.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone-file",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A DNS zone file parser and generator",
   "main": "lib/index",
   "scripts": {
@@ -28,6 +28,9 @@
   "contributors": [
     {
       "name": "Ryan Shea"
+    },
+    {
+      "name": "Aaron Blankstein"
     },
     {
       "name": "Elgs Chen"

--- a/src/makeZoneFile.es6
+++ b/src/makeZoneFile.es6
@@ -115,13 +115,16 @@ let processTXT = function(data, template) {
         ret += (data[i].name || '@') + '\t';
         if (data[i].ttl) ret += data[i].ttl + '\t';
         ret += 'IN\tTXT\t';
-        if (data[i].txt instanceof String) {
-          ret += '"' + data[i].txt + '"';
-        } else if (data[i].txt instanceof Array) {
-          ret += data[i].txt.reduce(
-              function(joined, datum) {
-                  return joined + ' "' + datum + '"';
-              });
+        let txtData = data[i].txt
+        if (txtData instanceof String || typeof(txtData) === 'string') {
+          ret += '"' + txtData + '"';
+        } else if (txtData instanceof Array) {
+          ret += txtData
+            .map(
+              function (datum) {
+                return '"' + datum + '"';
+              })
+            .join(' ');
         }
         ret += '\n';
     }

--- a/src/makeZoneFile.es6
+++ b/src/makeZoneFile.es6
@@ -115,7 +115,7 @@ let processTXT = function(data, template) {
         ret += (data[i].name || '@') + '\t';
         if (data[i].ttl) ret += data[i].ttl + '\t';
         ret += 'IN\tTXT\t';
-        let txtData = data[i].txt
+        const txtData = data[i].txt
         if (txtData instanceof String || typeof(txtData) === 'string') {
           ret += '"' + txtData + '"';
         } else if (txtData instanceof Array) {

--- a/src/makeZoneFile.es6
+++ b/src/makeZoneFile.es6
@@ -114,7 +114,16 @@ let processTXT = function(data, template) {
     for (let i in data) {
         ret += (data[i].name || '@') + '\t';
         if (data[i].ttl) ret += data[i].ttl + '\t';
-        ret += 'IN\tTXT\t"' + data[i].txt + '"\n';
+        ret += 'IN\tTXT\t';
+        if (data[i].txt instanceof String) {
+          ret += '"' + data[i].txt + '"';
+        } else if (data[i].txt instanceof Array) {
+          ret += data[i].txt.reduce(
+              function(joined, datum) {
+                  return joined + ' "' + datum + '"';
+              });
+        }
+        ret += '\n';
     }
     return template.replace('{txt}', ret);
 };

--- a/src/parseZoneFile.es6
+++ b/src/parseZoneFile.es6
@@ -171,13 +171,27 @@ let parseMX = function(rr) {
 let parseTXT = function(rr) {
     let rrTokens = rr.trim().match(/[^\s\"']+|\"[^\"]*\"|'[^']*'/g);
     let l = rrTokens.length;
-    let tokenTxt = rrTokens[l - 1]
-    if (tokenTxt.indexOf('\"') > -1) {
-        tokenTxt = tokenTxt.split('\"')[1]
+    let indexTXT = rrTokens.indexOf('TXT');
+
+    let stripText = function(txt) {
+        if (txt.indexOf('\"') > -1) {
+            txt = txt.split('\"')[1];
+        }
+        if (txt.indexOf('"') > -1) {
+            txt = txt.split('"')[1];
+        }
+        return txt;
     }
-    if (tokenTxt.indexOf('"') > -1) {
-        tokenTxt = tokenTxt.split('"')[1]
+
+    let tokenTxt;
+    if (l - indexTXT - 1 > 1) {
+        tokenTxt = rrTokens
+            .slice(indexTXT + 1)
+            .map(stripText);
+    } else {
+        tokenTxt = stripText(rrTokens[l - 1]);
     }
+
     let result = {
         name: rrTokens[0],
         txt: tokenTxt

--- a/src/testing/unitTests.es6
+++ b/src/testing/unitTests.es6
@@ -19,6 +19,11 @@ let zoneFileReferences = [{
   json: require('../../testData/zonefile_forward_3.json'),
   text: fs.readFileSync('./testData/zonefile_forward_3.txt', 'utf8'),
   records: ['uri']
+}, {
+  name: 'Multitext',
+  json: require('../../testData/zonefile_forward_4.json'),
+  text: fs.readFileSync('./testData/zonefile_reverse_multitxt.txt', 'utf8'),
+  records: ['uri', 'txt']
 }]
 
 function testZoneFileToText(zoneFileReference) {
@@ -49,7 +54,7 @@ function testZoneFileToJson(zoneFileReference) {
       t.equal(zoneFileJson['mx'][0]['preference'], zoneFileReference.json['mx'][0]['preference'])
     }
     if (zoneFileReference.records.indexOf('txt') > -1) {
-      t.equal(zoneFileJson['txt'][0]['txt'], zoneFileReference.json['txt'][0]['txt'])
+      t.deepEqual(zoneFileJson['txt'][0]['txt'], zoneFileReference.json['txt'][0]['txt'])
     }
     if (zoneFileReference.records.indexOf('uri') > -1) {
       t.equal(zoneFileJson['uri'][0]['target'], zoneFileReference.json['uri'][0]['target'])

--- a/src/testing/unitTests.es6
+++ b/src/testing/unitTests.es6
@@ -24,7 +24,26 @@ let zoneFileReferences = [{
   json: require('../../testData/zonefile_forward_4.json'),
   text: fs.readFileSync('./testData/zonefile_reverse_multitxt.txt', 'utf8'),
   records: ['uri', 'txt']
-}]
+},
+{
+  name: 'blockstack-client CLI constructed zonefile',
+  json: require('../../testData/blockstack-cli-zonefile.json'),
+  text: fs.readFileSync('./testData/blockstack-cli-zonefile.txt', 'utf8'),
+  records: ['uri', 'txt']
+},
+{
+  name: 'onename transfer constructed zonefile',
+  json: require('../../testData/onename-transfer-zonefile.json'),
+  text: fs.readFileSync('./testData/onename-transfer-zonefile.txt', 'utf8'),
+  records: ['uri']
+},
+{
+  name: 'browser generated zonefile',
+  json: require('../../testData/browser-generated-zonefile.json'),
+  text: fs.readFileSync('./testData/browser-generated-zonefile.txt', 'utf8'),
+  records: ['uri']
+}
+]
 
 function testZoneFileToText(zoneFileReference) {
   test(zoneFileReference.name + ' testToText', (t) => {

--- a/testData/blockstack-cli-zonefile.json
+++ b/testData/blockstack-cli-zonefile.json
@@ -1,0 +1,14 @@
+{ "$origin": "ablankstein.id",
+  "$ttl": 3600,
+  "txt":
+  [ { "name": "pubkey",
+      "txt": "pubkey:data:045a501e341fbf1b403ce3a6e66836a3a40a06d76f62ee46d22f39b280b3eb0e6a9c44f7a06645bac259fcf7703a74b794dd805559db30f780e5cf4c63e5646730" } ],
+  "uri":
+  [ { "name": "_https._tcp",
+      "target": "https://blockstack.s3.amazonaws.com/ablankstein.id",
+      "priority": 10,
+      "weight": 1 },
+    { "name": "_https._tcp",
+      "target": "https://www.cs.princeton.edu/~ablankst/profile.json",
+      "priority": 10,
+      "weight": 1 } ] }

--- a/testData/blockstack-cli-zonefile.txt
+++ b/testData/blockstack-cli-zonefile.txt
@@ -1,0 +1,5 @@
+$ORIGIN ablankstein.id
+$TTL 3600
+pubkey TXT "pubkey:data:045a501e341fbf1b403ce3a6e66836a3a40a06d76f62ee46d22f39b280b3eb0e6a9c44f7a06645bac259fcf7703a74b794dd805559db30f780e5cf4c63e5646730"
+_https._tcp URI 10 1 "https://blockstack.s3.amazonaws.com/ablankstein.id"
+_https._tcp URI 10 1 "https://www.cs.princeton.edu/~ablankst/profile.json"

--- a/testData/browser-generated-zonefile.json
+++ b/testData/browser-generated-zonefile.json
@@ -1,0 +1,7 @@
+{ "$origin": "fork_party.id",
+  "$ttl": 3600,
+  "uri":
+   [ { "name": "_http._tcp",
+       "target": "https://blockstakuserstorage.blob.core.windows.net/productionuserstorage/user_1P4AkXeLcp2rfUiX8UXnERYGhnYo7tZUSs/fork_party.id.json",
+       "priority": 10,
+       "weight": 1 } ] }

--- a/testData/browser-generated-zonefile.txt
+++ b/testData/browser-generated-zonefile.txt
@@ -1,0 +1,3 @@
+$ORIGIN fork_party.id
+$TTL 3600
+_http._tcp URI 10 1 "https://blockstakuserstorage.blob.core.windows.net/productionuserstorage/user_1P4AkXeLcp2rfUiX8UXnERYGhnYo7tZUSs/fork_party.id.json"

--- a/testData/onename-transfer-zonefile.json
+++ b/testData/onename-transfer-zonefile.json
@@ -1,0 +1,7 @@
+{ "$origin": "aaron.id",
+  "$ttl": 3600,
+  "uri":
+   [ { "name": "_http._tcp",
+       "target": "https://gaia.blockstack.org/hub/34bNQUVgyhSrA8XpM4HkerHUUdNmLpiyj7/0/profile.json",
+       "priority": 10,
+       "weight": 1 } ] }

--- a/testData/onename-transfer-zonefile.txt
+++ b/testData/onename-transfer-zonefile.txt
@@ -1,0 +1,3 @@
+$ORIGIN aaron.id
+$TTL 3600
+_http._tcp URI 10 1 "https://gaia.blockstack.org/hub/34bNQUVgyhSrA8XpM4HkerHUUdNmLpiyj7/0/profile.json"

--- a/testData/zonefile_forward_4.json
+++ b/testData/zonefile_forward_4.json
@@ -1,0 +1,24 @@
+{
+  "$origin": "naval.id",
+  "$ttl": 3600,
+  "uri": [
+    {
+      "name": "_http._tcp",
+      "priority": 10,
+      "weight": 1,
+      "target": "https://mq9.s3.amazonaws.com/naval.id/profile.json"
+    }
+  ],
+  "txt": [
+    {
+      "name": "created_equal",
+      "ttl": 15,
+      "txt": [
+        "owner=1AYddAnfHbw6bPNvnsQFFrEuUdhMhf2XG9",
+        "seqn=0",
+        "parts=1",
+        "zf0=JE9SSUdJTiBjcmVhdGVkX2VxdWFsCiRUVEwgMzYwMApfaHR0cHMuX3RjcCBVUkkgMTAgMSAiaHR0cHM6Ly93d3cuY3MucHJpbmNldG9uLmVkdS9+YWJsYW5rc3QvY3JlYXRlZF9lcXVhbC5qc29uIgpfZmlsZSBVUkkgMTAgMSAiZmlsZTovLy90bXAvY3JlYXRlZF9lcXVhbC5qc29uIgo="
+      ]
+    }
+  ]
+}

--- a/testData/zonefile_reverse_multitxt.txt
+++ b/testData/zonefile_reverse_multitxt.txt
@@ -1,0 +1,4 @@
+$ORIGIN naval.id
+$TTL 3600
+_http._tcp IN URI 10 1 "https://mq9.s3.amazonaws.com/naval.id/profile.json"
+created_equal IN TXT "owner=1AYddAnfHbw6bPNvnsQFFrEuUdhMhf2XG9" "seqn=0" "parts=1" "zf0=JE9SSUdJTiBjcmVhdGVkX2VxdWFsCiRUVEwgMzYwMApfaHR0cHMuX3RjcCBVUkkgMTAgMSAiaHR0cHM6Ly93d3cuY3MucHJpbmNldG9uLmVkdS9+YWJsYW5rc3QvY3JlYXRlZF9lcXVhbC5qc29uIgpfZmlsZSBVUkkgMTAgMSAiZmlsZTovLy90bXAvY3JlYXRlZF9lcXVhbC5qc29uIgo="


### PR DESCRIPTION
RFC 1464 (https://tools.ietf.org/html/rfc1464) compliant TXT record support:

A record like:
```
joe        IN      TXT    "Located in a black hole" "Likely to be eaten by a grue"
```

Should parse to an object like
```javascript
{ ...
  txt: [ { name: 'joe',
            txt: ['Located in a black hole', 'Likely to be eaten by a grue'] } ]
}
```

In order to maintain backwards-compatibility, TXT records with only a single string yield objects with 'txt' fields of type `String`, rather than `Array<String>`

This feature is required to support correctly parsing and generating DNS zonefiles with Blockstack subdomain operations.

This PR adds a test case for multiple-string TXT records, and adds 3 test cases based on zonefiles generated by different Blockstack tools (to further ensure our backwards compatibility).
